### PR TITLE
JWT now contains user information

### DIFF
--- a/middleware/boot-spa.global.ts
+++ b/middleware/boot-spa.global.ts
@@ -10,13 +10,18 @@ export default defineNuxtRouteMiddleware(async () => {
 
   const authStore = useAuthStore();
   if (!authStore.isAppBooted) {
-    authStore.loadUserData();
+    const hasToken = authStore.loadUserData();
+    if (hasToken) {
+      // Refresh token on app boot if it’s valid
+      await authStore.refreshIfValid();
+    }
     authStore.isAppBooted = true;
   }
 
   if (!authStore.isLoggedIn) return;
 
-  if (isTokenExpired(authStore.expiresEpoch)) {
+  // Refresh if token is about to expire (e.g., within 30 seconds)
+  if (isTokenExpired(authStore.expiresEpoch - 30)) {
     if (!(await tryRefreshToken(authStore.refreshToken))) return;
   }
 });

--- a/middleware/boot-spa.global.ts
+++ b/middleware/boot-spa.global.ts
@@ -5,60 +5,39 @@ import { isTokenExpired } from '~/services/auth-service';
 import useAuthStore from '~/stores/auth-store';
 import useExternalToastStore from '~/stores/external-toast-store';
 
-/**
- * This middleware only works for SPA applications. DS4F is meant only for SPAs, so if you are
- * trying to do SSR, you may be looking for other middleware
- */
 export default defineNuxtRouteMiddleware(async () => {
-  // Checks if the process is executing in client-side
-  if (!import.meta.client) {
-    return;
-  }
+  if (!import.meta.client) return;
 
   const authStore = useAuthStore();
-  // The app boot should only happen once
   if (!authStore.isAppBooted) {
     authStore.loadUserData();
+    authStore.isAppBooted = true;
   }
 
-  // If the user isn't logged in the rest of the function isn't needed.
-  if (!authStore.isLoggedIn) {
-    return;
-  }
-  // If the token is expired it will be refreshed. If the session is sucessfully refreshed
-  // the function continues. If not, finish the execution of the function.
+  if (!authStore.isLoggedIn) return;
+
   if (isTokenExpired(authStore.expiresEpoch)) {
-    if (!(await tryRefreshToken(authStore.refreshToken))) {
-      return;
-    }
-  }
-
-  // The user data is refreshed one time when the app boots.
-  // Remove or comment the following 3 lines of code if the app doesn't need to refresh the data
-  if (!authStore.isUserRefreshed) {
-    authStore.refreshUserData();
+    if (!(await tryRefreshToken(authStore.refreshToken))) return;
   }
 });
 
-// If the token could be refreshed returns true, false otherwise.
 async function tryRefreshToken(
   refreshTokenCallback: () => Promise<void>
 ): Promise<boolean> {
   try {
-    // Here something should be triggered to let the user know the app is loading.
     await refreshTokenCallback();
     return true;
   } catch (error: unknown) {
-    const composablesToastStore = useExternalToastStore();
+    const toastStore = useExternalToastStore();
     if (error instanceof ExpiredTokenException) {
-      composablesToastStore.addToast({
+      toastStore.addToast({
         severity: 'error',
         detail: 'error.409.session_expired',
         life: 6000
       });
     }
     if (error instanceof InvalidTokenException) {
-      composablesToastStore.addToast({
+      toastStore.addToast({
         severity: 'error',
         detail: 'error.invalid_token',
         life: 6000

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@primevue/themes": "^4.2.1",
         "@vee-validate/zod": "^4.14.7",
         "@vortechron/query-builder-ts": "^1.2.0",
+        "jwt-decode": "^4.0.0",
         "nuxt": "^3.13.2",
         "nuxt-zod-i18n": "^1.11.5",
         "primeicons": "^7.0.0",
@@ -9077,6 +9078,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@primevue/themes": "^4.2.1",
     "@vee-validate/zod": "^4.14.7",
     "@vortechron/query-builder-ts": "^1.2.0",
+    "jwt-decode": "^4.0.0",
     "nuxt": "^3.13.2",
     "nuxt-zod-i18n": "^1.11.5",
     "primeicons": "^7.0.0",

--- a/services/auth-service.ts
+++ b/services/auth-service.ts
@@ -1,10 +1,11 @@
-import type { User } from "~/types/user";
+import { jwtDecode } from 'jwt-decode';
+import type { User } from '~/types/user';
 
 export const AUTH_ENDPOINT = {
-  LOGIN: "/login",
-  REFRESH: "/token",
-  LOGOUT: "/logout",
-  LOGGED_USER_INFO: "/me",
+  LOGIN: '/login',
+  REFRESH: '/token',
+  LOGOUT: '/logout',
+  LOGGED_USER_INFO: '/me'
 } as const;
 
 export type AuthEndpoint = (typeof AUTH_ENDPOINT)[keyof typeof AUTH_ENDPOINT];
@@ -13,28 +14,28 @@ export type AuthEndpoint = (typeof AUTH_ENDPOINT)[keyof typeof AUTH_ENDPOINT];
  * Saves a the DS JWT token to localStorage.
  */
 export function saveToken(token: string): void {
-  localStorage.setItem("ds-jwt", token);
+  localStorage.setItem('ds-jwt', token);
 }
 
 /**
  * Saves a user object to localStorage.
  */
 export function saveUser(user: User): void {
-  localStorage.setItem("user", JSON.stringify(user));
+  localStorage.setItem('user', JSON.stringify(user));
 }
 
 /**
  * Saves the DS JWT token expire epoch (unix timestamp) to localStorage.
  */
 export function saveExpiresEpoch(expiresIn: number): void {
-  localStorage.setItem("expiresEpoch", String(expiresIn));
+  localStorage.setItem('expiresEpoch', String(expiresIn));
 }
 
 /**
  * Checks if the DS JWT token exists in localStorage and returns it. Returns false if not found.
  */
 export function isPotentiallyLoggedIn(): boolean | string {
-  const token = localStorage.getItem("ds-jwt");
+  const token = localStorage.getItem('ds-jwt');
   return token !== null ? token : false;
 }
 
@@ -42,7 +43,7 @@ export function isPotentiallyLoggedIn(): boolean | string {
  * Retrieves the user object from localStorage. Returns false if not found.
  */
 export function getUserData(): boolean | User {
-  const user = localStorage.getItem("user");
+  const user = localStorage.getItem('user');
   return user !== null ? JSON.parse(user) : false;
 }
 
@@ -50,7 +51,7 @@ export function getUserData(): boolean | User {
  * Retrieves the expiration epoch from localStorage. Returns -1 if not found.
  */
 export function getExpiresEpoch(): number {
-  const expiresIn = localStorage.getItem("expiresEpoch");
+  const expiresIn = localStorage.getItem('expiresEpoch');
   return expiresIn !== null ? Number(expiresIn) : -1;
 }
 
@@ -65,9 +66,9 @@ export function getActualEpoch(): number {
  * Removes specific keys related to authentication from localStorage.
  */
 export function cleanSavedKeys(): void {
-  localStorage.removeItem("ds-jwt");
-  localStorage.removeItem("user");
-  localStorage.removeItem("expiresEpoch");
+  localStorage.removeItem('ds-jwt');
+  localStorage.removeItem('user');
+  localStorage.removeItem('expiresEpoch');
 }
 
 /**
@@ -83,4 +84,8 @@ export function calculateExpireEpoch(expiresIn: number): number {
 export function isTokenExpired(expiresEpoch: number): boolean {
   const epoch: number = getActualEpoch();
   return epoch >= expiresEpoch;
+}
+
+export function decodeToken(token: string): { user: User } {
+  return jwtDecode(token);
 }

--- a/services/auth-service.ts
+++ b/services/auth-service.ts
@@ -14,18 +14,9 @@ export function saveToken(token: string): void {
   localStorage.setItem('ds-jwt', token);
 }
 
-export function saveExpiresEpoch(expiresEpoch: number): void {
-  localStorage.setItem('expiresEpoch', String(expiresEpoch));
-}
-
 export function isPotentiallyLoggedIn(): boolean | string {
   const token = localStorage.getItem('ds-jwt');
   return token !== null ? token : false;
-}
-
-export function getExpiresEpoch(): number {
-  const expiresEpoch = localStorage.getItem('expiresEpoch');
-  return expiresEpoch !== null ? Number(expiresEpoch) : -1;
 }
 
 export function getActualEpoch(): number {
@@ -34,19 +25,15 @@ export function getActualEpoch(): number {
 
 export function cleanSavedKeys(): void {
   localStorage.removeItem('ds-jwt');
-  localStorage.removeItem('expiresEpoch');
-  localStorage.removeItem('user'); // Keep for backward compatibility
-}
-
-export function calculateExpireEpoch(expiresIn: number): number {
-  return getActualEpoch() + expiresIn - 30;
+  localStorage.removeItem('expiresEpoch'); // Clean up old data
+  localStorage.removeItem('user'); // Clean up old data
 }
 
 export function isTokenExpired(expiresEpoch: number): boolean {
   const epoch = getActualEpoch();
-  return epoch >= expiresEpoch;
+  return epoch >= expiresEpoch - 30; // Refresh 30 seconds early
 }
 
-export function decodeToken(token: string): { user: User } {
-  return jwtDecode(token);
+export function decodeToken(token: string): { user: User; exp: number } {
+  return jwtDecode<{ user: User; exp: number }>(token);
 }

--- a/services/auth-service.ts
+++ b/services/auth-service.ts
@@ -10,79 +10,40 @@ export const AUTH_ENDPOINT = {
 
 export type AuthEndpoint = (typeof AUTH_ENDPOINT)[keyof typeof AUTH_ENDPOINT];
 
-/**
- * Saves a the DS JWT token to localStorage.
- */
 export function saveToken(token: string): void {
   localStorage.setItem('ds-jwt', token);
 }
 
-/**
- * Saves a user object to localStorage.
- */
-export function saveUser(user: User): void {
-  localStorage.setItem('user', JSON.stringify(user));
+export function saveExpiresEpoch(expiresEpoch: number): void {
+  localStorage.setItem('expiresEpoch', String(expiresEpoch));
 }
 
-/**
- * Saves the DS JWT token expire epoch (unix timestamp) to localStorage.
- */
-export function saveExpiresEpoch(expiresIn: number): void {
-  localStorage.setItem('expiresEpoch', String(expiresIn));
-}
-
-/**
- * Checks if the DS JWT token exists in localStorage and returns it. Returns false if not found.
- */
 export function isPotentiallyLoggedIn(): boolean | string {
   const token = localStorage.getItem('ds-jwt');
   return token !== null ? token : false;
 }
 
-/**
- * Retrieves the user object from localStorage. Returns false if not found.
- */
-export function getUserData(): boolean | User {
-  const user = localStorage.getItem('user');
-  return user !== null ? JSON.parse(user) : false;
-}
-
-/**
- * Retrieves the expiration epoch from localStorage. Returns -1 if not found.
- */
 export function getExpiresEpoch(): number {
-  const expiresIn = localStorage.getItem('expiresEpoch');
-  return expiresIn !== null ? Number(expiresIn) : -1;
+  const expiresEpoch = localStorage.getItem('expiresEpoch');
+  return expiresEpoch !== null ? Number(expiresEpoch) : -1;
 }
 
-/**
- * Retrieves the current epoch time in seconds.
- */
 export function getActualEpoch(): number {
   return Math.floor(Date.now() / 1000);
 }
 
-/**
- * Removes specific keys related to authentication from localStorage.
- */
 export function cleanSavedKeys(): void {
   localStorage.removeItem('ds-jwt');
-  localStorage.removeItem('user');
   localStorage.removeItem('expiresEpoch');
+  localStorage.removeItem('user'); // Keep for backward compatibility
 }
 
-/**
- * Calculates the expiration epoch based on the current time and a given duration.
- */
 export function calculateExpireEpoch(expiresIn: number): number {
   return getActualEpoch() + expiresIn - 30;
 }
 
-/**
- * Checks if a tje DS JWT token has expired based on the expiration epoch.
- */
 export function isTokenExpired(expiresEpoch: number): boolean {
-  const epoch: number = getActualEpoch();
+  const epoch = getActualEpoch();
   return epoch >= expiresEpoch;
 }
 

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -59,7 +59,7 @@ export class UserService extends BaseService<User> {
 
   public async getRolesBelow(): Promise<FetchedResponse<Role[], unknown>> {
     return apiFetch<Role[], unknown>({
-      endpoint: `${this.endpoint}/rolesbelow`
+      endpoint: `${this.endpoint}/roles-below`
     });
   }
 }

--- a/stores/auth-store.ts
+++ b/stores/auth-store.ts
@@ -63,10 +63,10 @@ const useAuthStore = defineStore('authStore', () => {
       throw new InvalidTokenException('');
     }
     token.value = data!.accessToken;
-    user.value = AuthService.decodeToken(token.value).user;
-    expiresEpoch.value = AuthService.calculateExpireEpoch(data!.expiresIn);
+    const decoded = AuthService.decodeToken(token.value);
+    user.value = decoded.user;
+    expiresEpoch.value = decoded.exp; // Use exp from JWT
     AuthService.saveToken(token.value);
-    AuthService.saveExpiresEpoch(expiresEpoch.value);
   }
 
   async function login(credentials: DefaultLoginCredentials): Promise<boolean> {
@@ -82,10 +82,10 @@ const useAuthStore = defineStore('authStore', () => {
     }
 
     token.value = data!.accessToken;
-    user.value = AuthService.decodeToken(token.value).user;
-    expiresEpoch.value = AuthService.calculateExpireEpoch(data!.expiresIn);
+    const decoded = AuthService.decodeToken(token.value);
+    user.value = decoded.user;
+    expiresEpoch.value = decoded.exp; // Use exp from JWT
     AuthService.saveToken(token.value);
-    AuthService.saveExpiresEpoch(expiresEpoch.value);
 
     return true;
   }
@@ -112,11 +112,11 @@ const useAuthStore = defineStore('authStore', () => {
 
   function loadUserData() {
     const lsToken = localStorage.getItem('ds-jwt');
-    const lsExpiresEpoch = localStorage.getItem('expiresEpoch');
-    if (lsToken && lsExpiresEpoch) {
+    if (lsToken) {
       token.value = lsToken;
-      user.value = AuthService.decodeToken(token.value).user;
-      expiresEpoch.value = Number(lsExpiresEpoch);
+      const decoded = AuthService.decodeToken(token.value);
+      user.value = decoded.user;
+      expiresEpoch.value = decoded.exp; // Use exp from JWT
       return true;
     }
     return false;

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,8 +1,9 @@
 export interface JWTResponse {
   accessToken: string;
   tokenType: string;
-  expiresIn: number;
+  expiresIn?: number;
 }
+
 export interface DefaultLoginCredentials {
   email: string;
   password: string;


### PR DESCRIPTION
The JWT now contains the user information, so that is no longer required to call the /me endpoint. Also, the JWT expire date is calculated by decoding the JWT instead of relying on the server.